### PR TITLE
chore: bump sdk/build tools on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.2"
+    compileSdkVersion 33
+    buildToolsVersion = "33.0.0"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 26
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
This is needed to fix a build issue on the new React-Native branch: https://github.com/innovactorybv/tripps-app/pull/807